### PR TITLE
fix: pin a barman compatible google-api-core release

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
           max_attempts: 3
           command: |
             # pip-tools provides pip-compile used by update.sh
-            pip3 install --upgrade pip-tools
+            pip3 install --upgrade pip-tools pip
             export PATH=$HOME/.local/bin:$PATH
             echo "Updating Debian images"
             ./Debian/update.sh

--- a/Debian/update.sh
+++ b/Debian/update.sh
@@ -150,6 +150,9 @@ update_requirements() {
 	# If there's a new version we need to recreate the requirements files
 	echo "barman[cloud,azure,snappy,google] == $barmanVersion" > requirements.in
 
+	# TODO: Remove once barman removes the `protobuf<3.18` requirement
+	echo "google-api-core <= 2.8.2" >> requirements.in
+
 	# This will take the requirements.in file and generate a file
 	# requirements.txt with the hashes for the required packages
 	pip-compile --generate-hashes 2> /dev/null


### PR DESCRIPTION
This will be reverted once barman removes the 'protobuf<3.18' requirement

Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>