### PR TITLE
fix: add workaround to install snappy on Bookworm

### DIFF
--- a/Debian/12/bookworm/Dockerfile
+++ b/Debian/12/bookworm/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install --break-system-packages --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/12/bullseye/Dockerfile
+++ b/Debian/12/bullseye/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install  --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install  --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/13/bookworm/Dockerfile
+++ b/Debian/13/bookworm/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install --break-system-packages --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/13/bullseye/Dockerfile
+++ b/Debian/13/bullseye/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install  --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install  --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/14/bookworm/Dockerfile
+++ b/Debian/14/bookworm/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install --break-system-packages --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/14/bullseye/Dockerfile
+++ b/Debian/14/bullseye/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install  --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install  --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/15/bookworm/Dockerfile
+++ b/Debian/15/bookworm/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install --break-system-packages --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/15/bullseye/Dockerfile
+++ b/Debian/15/bullseye/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install  --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install  --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/16/bookworm/Dockerfile
+++ b/Debian/16/bookworm/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install --break-system-packages --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/16/bullseye/Dockerfile
+++ b/Debian/16/bullseye/Dockerfile
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install  --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install  --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/17/bookworm/Dockerfile
+++ b/Debian/17/bookworm/Dockerfile
@@ -41,13 +41,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install --break-system-packages --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/17/bullseye/Dockerfile
+++ b/Debian/17/bullseye/Dockerfile
@@ -41,13 +41,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install  --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install  --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/Dockerfile-beta.template
+++ b/Debian/Dockerfile-beta.template
@@ -41,13 +41,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install %%PIP_OPTIONS%% --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install %%PIP_OPTIONS%% --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/Dockerfile.template
+++ b/Debian/Dockerfile.template
@@ -43,13 +43,27 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		# We require build dependencies to build snappy 0.6
+		# on Python 3.11 or greater.
+		# TODO: Remove build deps once barman unpins the snappy version or
+		# https://github.com/EnterpriseDB/barman/issues/905 is completed
+		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
 	; \
 	pip3 install %%PIP_OPTIONS%% --upgrade pip; \
-# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
+	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install %%PIP_OPTIONS%% --no-deps -r requirements.txt; \
+	# We require build dependencies to build snappy 0.6
+	# on Python 3.11 or greater.
+	# TODO: Remove build deps once barman unpins the snappy version or
+	# https://github.com/EnterpriseDB/barman/issues/905 is completed
+	apt-get remove -y --purge --autoremove \
+		build-essential \
+		python3-dev \
+		libsnappy-dev \
+	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26


### PR DESCRIPTION
Closes #109 