### PR TITLE
feat: add kustomization for ClusterImageCatalog manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,8 +196,9 @@ jobs:
         run: |
           yq eval-all '. as $item ireduce ({}; . *+ $item )' clusterimagecatalog/*-bullseye.yaml > Debian/ClusterImageCatalog-bullseye.yaml
           yq eval-all '. as $item ireduce ({}; . *+ $item )' clusterimagecatalog/*-bookworm.yaml > Debian/ClusterImageCatalog-bookworm.yaml
+          yq -i '.resources[0] |= "ClusterImageCatalog-" + env(DEFAULT_DISTRO) + ".yaml"' Debian/kustomization.yaml
           ln -f -s ClusterImageCatalog-${DEFAULT_DISTRO}.yaml Debian/ClusterImageCatalog.yaml
-          cat Debian/ClusterImageCatalog.yaml Debian/ClusterImageCatalog-bullseye.yaml Debian/ClusterImageCatalog-bookworm.yaml
+          cat Debian/kustomization.yaml Debian/ClusterImageCatalog.yaml Debian/ClusterImageCatalog-bullseye.yaml Debian/ClusterImageCatalog-bookworm.yaml
 
       - name: Temporarily disable "include administrators" branch protection
         if: ${{ always() && github.ref == 'refs/heads/main' }}

--- a/Debian/kustomization.yaml
+++ b/Debian/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ClusterImageCatalog-bullseye.yaml


### PR DESCRIPTION
This adds a [kustomization file](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) that always includes the latest ClusterImageCatalog manifest for the default distribution.

cdc86b77be5ac72bbce39136a5e56e140d2aad2a added support for multiple Debian releases, and changed the `ClusterImageCatalog.yaml` from a file to a symlink. This is great if you have the repo cloned, but it broke several install methods, including [what's listed in the CNPG docs](https://cloudnative-pg.io/documentation/current/image_catalog#postgresql-container-images):
* `kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog.yaml` (as listed in the docs) fails with `error validating data: invalid object to validate [...]`
* Inclusion in a kustomization.yaml file i.e.
    
    ```yaml
    ---
    apiVersion: kustomize.config.k8s.io/v1beta1
    kind: Kustomization
    resources:
      - https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/refs/heads/main/Debian/ClusterImageCatalog.yaml
    ```
    
    fails with `error: accumulating resources: accumulation err [...] missing Resource metadata': [...]`
* Installation via flux CD with a git source fails as flux deletes symlinks for security reasons

This fixes all of the above install methods (and probably others) by adding a `kustomization.yaml` file. Users can specify this file, or in some cases the Debian directory, to install the correct manifest:
* `kubectl apply -k kubectl apply -k https://github.com/cloudnative-pg/postgres-containers//Debian/?ref=main`
* Inclusion in a kustomization.yaml file i.e.
    
    ```yaml
    ---
    apiVersion: kustomize.config.k8s.io/v1beta1
    kind: Kustomization
    resources:
      - https://github.com/cloudnative-pg/postgres-containers//Debian/?ref=main
    ```
* Flux CD git source and Kustomization with `path: /Debian`

The file will be automatically when the CD pipeline is ran, just like the symlinked `ClusterImageCatalog.yaml`.