### PR TITLE
fix: set a fixed version of Barman to 3.11.1

### DIFF
--- a/lib/repo_funcs.sh
+++ b/lib/repo_funcs.sh
@@ -32,7 +32,8 @@ fetch_postgres_image_version() {
 # Get the latest Barman version
 latest_barman_version=
 _raw_get_latest_barman_version() {
-	curl -s https://pypi.org/pypi/barman/json | jq -r '.releases | keys[]' | sort -Vr | head -n1
+#	curl -s https://pypi.org/pypi/barman/json | jq -r '.releases | keys[]' | sort -Vr | head -n1
+	echo "3.11.1"
 }
 get_latest_barman_version() {
 	if [ -z "$latest_barman_version" ]; then


### PR DESCRIPTION
The latest released version of Barman 3.12.0 introduced a change of the format making that version incompatible with CloudNativePG

For more information check the following commit:
https://github.com/EnterpriseDB/barman/pull/1029/files

Closes #120 