### PR TITLE
chore: remove build-essentials from the install package

### DIFF
--- a/Debian/Dockerfile-beta.template
+++ b/Debian/Dockerfile-beta.template
@@ -41,11 +41,6 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		# We require build dependencies to build snappy 0.6
-		# on Python 3.11 or greater.
-		# TODO: Remove build deps once barman unpins the snappy version or
-		# https://github.com/EnterpriseDB/barman/issues/905 is completed
-		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
@@ -53,15 +48,6 @@ RUN set -xe; \
 	pip3 install %%PIP_OPTIONS%% --upgrade pip; \
 	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install %%PIP_OPTIONS%% --no-deps -r requirements.txt; \
-	# We require build dependencies to build snappy 0.6
-	# on Python 3.11 or greater.
-	# TODO: Remove build deps once barman unpins the snappy version or
-	# https://github.com/EnterpriseDB/barman/issues/905 is completed
-	apt-get remove -y --purge --autoremove \
-		build-essential \
-		python3-dev \
-		libsnappy-dev \
-	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26

--- a/Debian/Dockerfile.template
+++ b/Debian/Dockerfile.template
@@ -43,11 +43,6 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		# We require build dependencies to build snappy 0.6
-		# on Python 3.11 or greater.
-		# TODO: Remove build deps once barman unpins the snappy version or
-		# https://github.com/EnterpriseDB/barman/issues/905 is completed
-		build-essential python3-dev libsnappy-dev \
 		python3-pip \
 		python3-psycopg2 \
 		python3-setuptools \
@@ -55,15 +50,6 @@ RUN set -xe; \
 	pip3 install %%PIP_OPTIONS%% --upgrade pip; \
 	# TODO: Remove --no-deps once https://github.com/pypa/pip/issues/9644 is solved
 	pip3 install %%PIP_OPTIONS%% --no-deps -r requirements.txt; \
-	# We require build dependencies to build snappy 0.6
-	# on Python 3.11 or greater.
-	# TODO: Remove build deps once barman unpins the snappy version or
-	# https://github.com/EnterpriseDB/barman/issues/905 is completed
-	apt-get remove -y --purge --autoremove \
-		build-essential \
-		python3-dev \
-		libsnappy-dev \
-	; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Change the uid of postgres to 26


### PR DESCRIPTION
A couple of things were fixed in Barman that allow us to remove
the build-essentials and a bunch of development packages

Closes #117