### PR TITLE
fix: pin boto3

### DIFF
--- a/lib/repo_funcs.sh
+++ b/lib/repo_funcs.sh
@@ -166,6 +166,7 @@ update_requirements() {
 	barmanVersion=$(get_latest_barman_version)
 	# If there's a new version we need to recreate the requirements files
 	echo "barman[cloud,azure,snappy,google] == $barmanVersion" > requirements.in
+	echo "boto3 == 1.35.99" >> requirements.in
 
 	# This will take the requirements.in file and generate a file
 	# requirements.txt with the hashes for the required packages


### PR DESCRIPTION
Pin boto3 version to 1.35.99.
version 1.36.0 of boto3 is affected by https://github.com/boto/boto3/issues/4398.

Closes #139