### PR TITLE
ci: copy and sign prod images

### DIFF
--- a/.github/workflows/bake.yaml
+++ b/.github/workflows/bake.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Copy images
         run: |
-          images=$(echo '${{needs.testbuild.outputs.metadata}}' |
+          images=$(echo '${{ needs.testbuild.outputs.metadata }}' |
             jq -r '
               .[] as $items |
               (
@@ -170,11 +170,13 @@ jobs:
               --dest-creds ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
               docker://${testimageshaonly} docker://${prodimage}
           done
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
+
       - name: Sign images
         run: |
-          images=$(echo '${{needs.testbuild.outputs.metadata}}' |
+          images=$(echo '${{ needs.testbuild.outputs.metadata }}' |
             jq -r '.[] |
               (
                 ."image.name" |


### PR DESCRIPTION
Use skopeo to copy testing images to the production registry when they pass the security tests, instead of rebuilding them. After that, we sign the production images too.