### PR TITLE
feat: automated the update of PostgreSQL versions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -50,6 +50,10 @@ jobs:
             echo "Updating Debian bookworm images"
             ./Debian/update.sh -d bookworm
 
+      - name: Run update PostgreSQL versions
+        run: |
+          bash -x update_postgres.sh
+
       - name: Diff
         run: |
           git status

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,13 +26,7 @@ target "default" {
       "minimal",
       "standard"
     ]
-    pgVersion = [
-      "13.18",
-      "14.15",
-      "15.10",
-      "16.6",
-      "17.2"
-    ]
+    pgVersion = ["13.18","14.15","15.10","16.6","17.2"]
     base = [
       // renovate: datasource=docker versioning=loose
       "debian:bookworm-slim@sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7",

--- a/update_postgres.sh
+++ b/update_postgres.sh
@@ -1,0 +1,5 @@
+set -Eeuo pipefail
+
+VERSIONS=$(curl -Ss -q https://www.postgresql.org/versions.json | jq -c  '[.[] | select(.supported == true) | .major + "."+.latestMinor]')
+
+sed -i -e 's/\(.*pgVersion = .*\)\(\[.*\]\)/\1'$VERSIONS'/' docker-bake.hcl


### PR DESCRIPTION
Now we use the official PostgreSQL site to get the latest and supported
versions of PostgreSQL, this will automatically:

* Update the PostgreSQL version of the current supported versions
* Deprecated unsupported versions of PostgreSQL

Closes #153 