### PR TITLE
Enable pinGitHubActionDigests for renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,12 @@
     {
       "matchPackageNames": ["debian"],
       "groupName": "Debian base images"
+    },
+    {
+      "matchDepTypes": [
+          "action"
+      ],
+      "pinDigests": true
     }
   ]
 }


### PR DESCRIPTION
Enable helpers:pinGitHubActionDigests to pin github actions with a commit hash
https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests

It is recommended here by Github: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions