### PR TITLE
build: halt build if PG can have a minor upgrade

### DIFF
--- a/Debian/Dockerfile.template
+++ b/Debian/Dockerfile.template
@@ -31,6 +31,11 @@ COPY requirements.txt /
 # Install additional extensions
 RUN set -xe; \
 	apt-get update; \
+	if apt list --upgradable 2>/dev/null | grep -q '^postgres'; then \
+		echo "ERROR: Upgradable postgres packages found!"; \
+		apt list --upgradable 2>/dev/null | grep '^postgres'; \
+		exit 1; \
+	fi; \
 	apt-get install -y --no-install-recommends \
 		"postgresql-${PG_MAJOR}-pgaudit" \
 		"postgresql-${PG_MAJOR}-pgvector" \


### PR DESCRIPTION
When building a system image, we start from a community postgres image. There is the chance that newer postgres packages are released, and they could be upgraded when installing the supported extensions. We want to prevent this scenario, as it could lead to unexpected versions in the container image.

Closes #186