### PR TITLE
chore: remove unnecessary line for Vim editor

### DIFF
--- a/Debian/Dockerfile-beta.template
+++ b/Debian/Dockerfile-beta.template
@@ -1,4 +1,3 @@
-# vim:set ft=dockerfile:
 #
 # Copyright The CloudNativePG Contributors
 #

--- a/Debian/Dockerfile.template
+++ b/Debian/Dockerfile.template
@@ -1,4 +1,3 @@
-# vim:set ft=dockerfile:
 #
 # Copyright The CloudNativePG Contributors
 #


### PR DESCRIPTION
In some system this produce a security issue documented here: 
https://security-tracker.debian.org/tracker/CVE-2023-52425