### PR TITLE
fix: ensure /var/lib/postgresql/data doesn't exist is system containers

### DIFF
--- a/Debian/Dockerfile-beta.template
+++ b/Debian/Dockerfile-beta.template
@@ -28,7 +28,8 @@ LABEL org.opencontainers.image.description="This Docker image contains PostgreSQ
 COPY requirements.txt /
 
 # Install additional extensions
-# RUN set -xe; \
+RUN set -xe; \
+	rm -fr /var/lib/postgresql/data
 #	apt-get update; \
 #	apt-get install -y --no-install-recommends \
 #		"postgresql-${PG_MAJOR}-pgvector" \

--- a/Debian/Dockerfile.template
+++ b/Debian/Dockerfile.template
@@ -29,6 +29,7 @@ COPY requirements.txt /
 
 # Install additional extensions
 RUN set -xe; \
+	rm -fr /var/lib/postgresql/data; \
 	apt-get update; \
 	if apt-get -s upgrade | grep "^Inst postgres"; then \
 		echo "ERROR: Upgradable postgres packages found!"; \


### PR DESCRIPTION
Since commit https://github.com/docker-library/postgres/commit/b9a533c87bdd767c228bf4c7490f9a6437a7d9f3, `docker-library/postgres` modified `/var/lib/postgresql/data` to be a symbolic link  of `/var/lib/postgresql`.
This is a breaking change that makes `docker-library/postgres` images that are v18 or greater unusable with CNPG, given that the operator uses that PATH to mount the "data" Persistent Volume.

So, as a workaround, we ensure `/var/lib/postgresql/data` do not exists.

Closes #247 