### PR TITLE
docs: update image signature context

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ software components and build dependencies.
 
 ## Image Signatures
 
-CloudNativePG container images are securely signed using
+The [`minimal`](#minimal-images) and [`standard`](#standard-images) CloudNativePG container images are securely signed using
 [cosign](https://github.com/sigstore/cosign), a tool within the
 [Sigstore](https://www.sigstore.dev/) ecosystem.
 This signing process is automated via GitHub Actions and leverages


### PR DESCRIPTION
This change makes it clear that _only_ `minimal` and `standard` images are signed. `System` images built with the old process were never signed to begin with - this old process is being deprecated. 

For details, see https://github.com/cloudnative-pg/postgres-containers/issues/245