### PR TITLE
chore(minimal): add LDAP libraries

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -116,10 +116,10 @@ you can deploy a temporary, disposable [distribution registry](https://distribut
 with the following command:
 
 ```bash
-docker run -d --rm -p 5000:5000 --name registry registry:2
+docker run -d --rm -p 5000:5000 --name registry registry:3
 ```
 
-This command runs a lightweight, temporary instance of the `registry:2`
+This command runs a lightweight, temporary instance of the `registry:3`
 container on port `5000`.
 
 ## Image Signing Workflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends -o Dpkg::::="--force-confdef" -o Dpkg::::="--force-confold" postgresql-common && \
     sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf && \
     apt-get install -y --no-install-recommends \
+      libsasl2-modules libldap-common \
       -o Dpkg::::="--force-confdef" -o Dpkg::::="--force-confold" "postgresql-${PG_MAJOR}=${PG_VERSION}*" && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/*


### PR DESCRIPTION
Include `libsasl2-modules` and `libldap-common` in the `minimal` image, given their small footprint.

Closes #261 