### PR TITLE
feat(docs): add section about bumping `Cluster` `imageName` using renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ As CloudNativePG's `Cluster` CRDs are not automatically picked up by renovate a 
 }
 ```
 
-Renovate will never change the `compatibility` part of the tag! So bumping from e.g., `trixie` to the next debian release must be done manually.
+Renovate will never change the `compatibility` part of the tag, ensuring that the upgraded images will remain compatible.
 
 ## License and copyright
 

--- a/README.md
+++ b/README.md
@@ -276,11 +276,12 @@ As CloudNativePG's `Cluster` CRDs are not automatically picked up by renovate a 
         '/\\.yaml$/',
       ],
       matchStrings: [
-        'imageName: (?<depName>\\S+):(?<currentValue>\\S+)@(?<currentDigest>sha256:[a-f0-9]+)',
+        'imageName: (?<depName>[^\\s:]+):(?<currentValue>[^\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?',
       ],
       datasourceTemplate: 'docker',
       // matches: 17.6-202509151215-minimal-trixie
       versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-(?<compatibility>\\S+)$',
+      autoReplaceStringTemplate: '{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}',
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -261,6 +261,33 @@ vulnerabilities before they are published or deployed:
 For detailed instructions on building PostgreSQL container images, refer to the
 [BUILD.md](BUILD.md) file.
 
+## Automatic Updating using Renovate
+
+[Renovate](https://github.com/renovatebot/renovate) can be used to automatically update various dependencies.
+As CloudNativePG's `Cluster` CRDs are not automatically picked up by renovate a custom regex manager must be configured:
+
+```json5
+{
+  customManagers: [
+    {
+      // cloudnative-pg instance version
+      customType: 'regex',
+      managerFilePatterns: [
+        '/\\.yaml$/',
+      ],
+      matchStrings: [
+        'imageName: (?<depName>\\S+):(?<currentValue>\\S+)@(?<currentDigest>sha256:[a-f0-9]+)',
+      ],
+      datasourceTemplate: 'docker',
+      // matches: 17.6-202509151215-minimal-trixie
+      versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-(?<compatibility>\\S+)$',
+    }
+  ]
+}
+```
+
+Renovate will never change the `compatibility` part of the tag! So bumping from e.g., `trixie` to the next debian release must be done manually.
+
 ## License and copyright
 
 This software is available under [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -261,33 +261,45 @@ vulnerabilities before they are published or deployed:
 For detailed instructions on building PostgreSQL container images, refer to the
 [BUILD.md](BUILD.md) file.
 
-## Automatic Updating using Renovate
+## Automated updates with Renovate
 
 [Renovate](https://github.com/renovatebot/renovate) can be used to automatically update various dependencies.
-As CloudNativePG's `Cluster` CRDs are not automatically picked up by renovate a custom regex manager must be configured:
+As CloudNativePG's `Cluster` CRDs are not automatically picked up by Renovate, a custom regex manager must be configured.
+The example below uses [JSON5](https://json5.org/); save it as `renovate.json5`, or convert keys/comments for use in `renovate.json`:
 
 ```json5
 {
   customManagers: [
     {
-      // cloudnative-pg instance version
+      // CloudNativePG Cluster imageName
       customType: 'regex',
       managerFilePatterns: [
         '/\\.yaml$/',
       ],
       matchStrings: [
-        'imageName: (?<depName>[^\\s:]+):(?<currentValue>[^\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?',
+        'imageName: (?<depName>[^\\s:]+):(?<currentValue>[^\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?',
       ],
       datasourceTemplate: 'docker',
       // matches: 17.6-202509151215-minimal-trixie
       versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-(?<compatibility>\\S+)$',
       autoReplaceStringTemplate: 'imageName: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}',
     }
+  ],
+  packageRules: [
+    {
+      matchPackageNames: ['ghcr.io/cloudnative-pg/postgresql'],
+      matchUpdateTypes: ['major'],
+      dependencyDashboardApproval: true,
+    }
   ]
 }
 ```
 
-Renovate will never change the `compatibility` part of the tag, ensuring that the upgraded images will remain compatible.
+Renovate will never change the `compatibility` part of the tag (image flavour and Debian base, e.g. `system-bookworm`), so upgrades stay on the same OS and glibc/ICU.
+Switching to a different base (e.g. from `bookworm` to `trixie`) is a manual operation because of [PostgreSQL locale-data implications](https://wiki.postgresql.org/wiki/Locale_data_changes).
+PostgreSQL major-version updates are routed through the [dependency dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) so they can be planned and applied by a human.
+To keep references fully reproducible, you can also enable [`pinDigests`](https://docs.renovatebot.com/configuration-options/#pindigests) scoped to the CloudNativePG image.
+If your repository contains other YAML manifests, narrow `managerFilePatterns` to the directory holding your `Cluster` resources, e.g. `'/clusters/.*\\.yaml$/'`.
 
 ## License and copyright
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ As CloudNativePG's `Cluster` CRDs are not automatically picked up by renovate a 
       datasourceTemplate: 'docker',
       // matches: 17.6-202509151215-minimal-trixie
       versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-(?<compatibility>\\S+)$',
-      autoReplaceStringTemplate: '{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}',
+      autoReplaceStringTemplate: 'imageName: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}',
     }
   ]
 }


### PR DESCRIPTION
This regex manager example can be used by users of renovate that want to also automate updates of their CNPG clusters.

Resolves #257