### PR TITLE
ci: disable provenance in metadata to avoid size limits

### DIFF
--- a/.github/workflows/bake_targets.yml
+++ b/.github/workflows/bake_targets.yml
@@ -100,6 +100,7 @@ jobs:
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         id: build
         env:
+          BUILDX_METADATA_PROVENANCE: disabled
           environment: testing
           registry: ghcr.io/${{ github.repository_owner }}
           revision: ${{ github.sha }}


### PR DESCRIPTION
Docker Buildx 0.31.0 includes full provenance attestations in the metadata output for multi-platform builds, resulting in 444KB+ JSON that exceeds bash argument list limits.

Setting BUILDX_METADATA_PROVENANCE=disabled excludes provenance from the metadata file while keeping attestations attached to images in the registry.

Related: cloudnative-pg/cloudnative-pg#9826