### PR TITLE
fix(build): compile Python bytecode during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && \
 		python3-setuptools \
 	&& \
 	pip3 install --no-cache-dir barman[cloud,azure,snappy,google,zstandard,lz4]==${BARMAN_VERSION} && \
+	python3 -c "import sysconfig, compileall; compileall.compile_dir(sysconfig.get_path('stdlib'), quiet=1); compileall.compile_dir(sysconfig.get_path('purelib'), quiet=1); compileall.compile_dir(sysconfig.get_path('platlib'), quiet=1)" && \
 	apt-get remove -y --purge --autoremove build-essential python3-dev && \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
 	rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/*


### PR DESCRIPTION
Compile all Python bytecode during the Docker build phase to prevent runtime compilation overhead and memory growth on read-only filesystems.

This applies the same fix from cloudnative-pg/plugin-barman-cloud@378c76a that resolved significant performance degradation and memory growth issues by ensuring Python bytecode is pre-compiled before the container becomes read-only.

Closes #385 