### PR TITLE
chore: enable Renovate's auto-merge

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Build images once a week, on Mondays
     - cron: 0 8 * * 1
+  pull_request:
   workflow_dispatch:
     inputs:
       environment:

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    ":gitSignOff",
+    ":automergeMinor",
+    ":automergeDigest"
   ],
   "enabledManagers": [
     "github-actions",


### PR DESCRIPTION
Enable renovate's auto-merge via default presets.
Allow builds & scans to run `on: pull_request`.

Closes #428 