### PR TITLE
chore(deps): drop python3-setuptools from barman install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update && \
 		build-essential python3-dev \
 		python3-pip \
 		python3-psycopg2 \
-		python3-setuptools \
 	&& \
 	pip3 install --no-cache-dir barman[cloud,azure,snappy,google,zstandard,lz4]==${BARMAN_VERSION} && \
 	python3 -c "import sysconfig, compileall; compileall.compile_dir(sysconfig.get_path('stdlib'), quiet=1); compileall.compile_dir(sysconfig.get_path('purelib'), quiet=1); compileall.compile_dir(sysconfig.get_path('platlib'), quiet=1)" && \


### PR DESCRIPTION
barman no longer depends on setuptools since 3.19.0, so the `python3-setuptools` build dependency is no longer required to install barman-cloud.