### PR TITLE
chore(renovate): avoid pinning a digest for local actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,15 @@
         "action"
       ],
       "pinDigests": true
+    },
+    {
+      "matchDepTypes": [
+        "action"
+      ],
+      "matchPackageNames": [
+        "/^cloudnative-pg\\/postgres-containers\\/\\.github\\/actions\\//"
+      ],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
Renovate with a global `pinDigest: true` tries pinning a digest also for local actions referenced via the 
`owner/repo[/path]@ref` pattern.
A new digest update for those actions would be generated every time there's a new commit on main, given that they live directly in this repository.