### PR TITLE
chore: fix renovate matchPackageNames for local actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,7 @@
         "action"
       ],
       "matchPackageNames": [
-        "/^cloudnative-pg\\/postgres-containers\\/\\.github\\/actions\\//"
+        "cloudnative-pg/postgres-containers"
       ],
       "pinDigests": false
     }


### PR DESCRIPTION
Follow up on #471 