### PR TITLE
chore: expand account names in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cloudnative-pg/maintainers @NiccoloFei @jbattiato @litaocdl
+* @gbartolini @mnencia @fcanovai @NiccoloFei @litaocdl


### PR DESCRIPTION
Remove @jbattiato (no actual commits, a leftover of the CODEOWNERS copy/paste from other projects).

Closes #475