### PR TITLE
ci: add workflow to cleanup -testing operand image

### DIFF
--- a/.github/workflows/registry-clean.yml
+++ b/.github/workflows/registry-clean.yml
@@ -1,0 +1,27 @@
+# This workflow runs daily to clean up the `*-testing` images older than the
+# cut-off period specified in `snok/container-retention-policy`
+name: clean-testing-package
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  IMAGE_NAME: "postgresql-testing"
+
+jobs:
+  clean-ghcr:
+    name: delete old testing container images
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete '-testing' operand images in ${{ env.IMAGE_NAME }}
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+        with:
+          image-names: ${{ env.IMAGE_NAME }}
+          cut-off: 1w
+          keep-n-most-recent: 1
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/registry-clean.yml
+++ b/.github/workflows/registry-clean.yml
@@ -7,6 +7,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: {}
+
 env:
   IMAGE_NAME: "postgresql-testing"
 
@@ -14,6 +16,7 @@ jobs:
   clean-ghcr:
     name: delete old testing container images
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Deletes -testing images older than 1 week, keeping the most recent tag.