### PR TITLE
chore(preview): bump PostgreSQL 19 preview to Beta 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository provides maintenance scripts for generating
 |    14   | 2021-09-30   | 2026-11-12 |
 |    13   | 2020-09-24   | 2025-11-13 |
 
-In addition, PostgreSQL 19 Beta 2 is provided for testing purposes only.
+In addition, PostgreSQL 19 Beta 3 is provided for testing purposes only.
 
 These images are designed to serve as operands of the
 [CloudNativePG (CNPG) operator](https://cloudnative-pg.io) in Kubernetes

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,7 +33,7 @@ postgreSQLVersions = [
 // Preview versions are automatically filtered out if present in the stable list
 // MANUALLY EDIT THE CONTENT - AND UPDATE THE README.md FILE TOO
 postgreSQLPreviewVersions = [
-  "19~beta2",
+  "19~beta3",
 ]
 
 // Barman version to build


### PR DESCRIPTION
PostgreSQL 19 Beta 3 was released today. Update the preview version list and README accordingly.