### PR TITLE
fix: run apt-get upgrade in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG PG_MAJOR
 ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends postgresql-common ca-certificates gnupg && \
     /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y -c "${PG_MAJOR}" && \
     apt-get install -y --no-install-recommends -o Dpkg::::="--force-confdef" -o Dpkg::::="--force-confold" postgresql-common && \
@@ -26,6 +27,7 @@ ARG EXTENSIONS
 ARG STANDARD_ADDITIONAL_POSTGRES_PACKAGES
 USER root
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends locales-all ${STANDARD_ADDITIONAL_POSTGRES_PACKAGES} ${EXTENSIONS} && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/*
@@ -40,6 +42,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 USER root
 RUN apt-get update && \
+    apt-get upgrade -y && \
 	apt-get install -y --no-install-recommends \
 		# We require build-essential and python3-dev to build lz4 on arm64 since there isn't a pre-compiled wheel available
 		build-essential python3-dev \


### PR DESCRIPTION
This brings in the latest security updates
from Debian when building the image.

Fixes #494